### PR TITLE
Sorted attributes and dates as ISO strings

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -58,7 +58,7 @@ Example
     >>> session.commit()
 
     >>> print(user)
-    <User id=1, name='spam', created=datetime.datetime(2016, 6, 1, 0, 0)>
+    <User id=1, name='spam', created='2016-06-01T00:00:00'>
 
 ``sqlalchemy_repr.PrettyRepresentableBase`` brings pretty, indented multi-line representation.
 
@@ -92,5 +92,5 @@ Example
         first_name='spam',
         last_name='ham',
         email='spam@example.com',
-        created=datetime.datetime(2016, 6, 1, 0, 0),
-        modified=datetime.datetime(2016, 6, 1, 0, 0)>
+        created='2016-06-01T00:00:00',
+        modified='2016-06-01T00:00:00'>

--- a/sqlalchemy_repr.py
+++ b/sqlalchemy_repr.py
@@ -41,6 +41,8 @@ class Repr(_Repr):
 
     def _repr_attr(self, obj, level):
         attr_name, attr_value = obj
+        if hasattr(attr_value, 'isoformat'):
+            return '%s=%r' % (attr_name, attr_value.isoformat())
         return '%s=%r' % (attr_name, attr_value)
 
     def _iter_attrs(self, obj):

--- a/tests/test_sqlalchemy_repr.py
+++ b/tests/test_sqlalchemy_repr.py
@@ -33,16 +33,22 @@ class TestRepr(unittest.TestCase):
         engine = create_engine('sqlite://')
         Base.metadata.create_all(engine)
         Session = sessionmaker(bind=engine)
+
+        self._date = datetime.now()
+        self._date_str = self._date.isoformat()
+
         self.session = Session()
-        self.user = User(name='spam', created=datetime.now())
         self.entry = Entry(title='ham', text=self.dummy_text, user_id=1)
+        self.user = User(name='spam', created=self._date)
         self.session.add(self.user)
         self.session.add(self.entry)
         self.session.commit()
 
     def test_repr_with_user(self):
         result = Repr().repr(self.user)
-        pattern = r"<User id=1, name=u?'spam', created=datetime\.datetime\(.*\)"
+        pattern = r"<User id=1, name=u?'spam', created='{0}'".format(
+            self._date_str
+        )
         self.assertMatch(result, pattern)
 
     def test_repr_with_entry(self):
@@ -56,7 +62,9 @@ class TestRepr(unittest.TestCase):
 
     def test_pretty_repr_with_user(self):
         result = PrettyRepr().repr(self.user)
-        pattern = r"<User\n    id=1,\n    name=u?'spam',\n    created=datetime\.datetime\(.*\)>"
+        pattern = r"<User\n    id=1,\n    name=u?'spam',\n    created='{0}'>".format(
+            self._date_str
+        )
         self.assertMatch(result, pattern)
 
     def test_pretty_repr_with_entry(self):


### PR DESCRIPTION
Hi!

I like to see my `id` first, then the rest of attributes sorted alphabetically. Also, I like dates as ISO strings.

All this is completely subjective, but if you like it, please merge :)
